### PR TITLE
Fix: body is not set to nil before ctx.body assigment

### DIFF
--- a/cqp/httpd.lua
+++ b/cqp/httpd.lua
@@ -124,7 +124,7 @@ local function handle_connection(params, con)
 			end
 		end
 
-		local code, body, reply = nil, nil, { headers = {} }
+		local code, reply = nil, { headers = {} }
 		if version >= 0.9 and version < 2.0 then
 			local ctx = {
 				http_version = version,


### PR DESCRIPTION
bug: body was set to nil before it was passed into ctx.body. This didn't do any harm when POST payload was "application/x-www-form-urlencoded" but when it was JSON the REST API could not get the input data. Now the body is NOT set to nil before assignment.
