### PR TITLE
Case-insensitive HTTP request headers

### DIFF
--- a/cqp/httpd.lua
+++ b/cqp/httpd.lua
@@ -104,24 +104,24 @@ local function handle_connection(params, con)
 		local hdr = {}
 		for h in con:lines("*h") do
 			local f, b = h:match("^([^:%s]+)%s*:%s*(.*)$")
-			hdr[f] = b
+			hdr[f:lower()] = b
 		end
 		con:read("*l") -- discard header/body break
 
 		local keep_alive = version >= 1.1
-		for _, option in ipairs(plstringx.split(hdr["Connection"] or "", "[ .]+")) do
+		for _, option in ipairs(plstringx.split(hdr["connection"] or "", "[ .]+")) do
 			if option == "keep-alive" then keep_alive = true
 			elseif option == "close" then keep_alive = false end
 		end
 
 		local body = nil
-		if hdr["Content-Length"] then
-			body = con:read(tonumber(hdr["Content-Length"]))
+		if hdr["content-length"] then
+			body = con:read(tonumber(hdr["content-length"]))
 		end
 
 		local paths, args = parseurl(path)
 		if body then
-			local content_type = (hdr["Content-Type"] or ""):match("^([^;]+)")
+			local content_type = (hdr["content-type"] or ""):match("^([^;]+)")
 			if content_type == "application/x-www-form-urlencoded" then
 				for key, val in body:gmatch("([^&=]+)=?([^&]+)") do
 					args[key] = val

--- a/cqp/httpd.lua
+++ b/cqp/httpd.lua
@@ -178,7 +178,7 @@ local function handle_connection(params, con)
 		end
 		con:write("\n")
 
-		if body and method ~= "HEAD" then con:write(body) end
+		if body and method ~= "HEAD" then con:xwrite(body, "bn") end
 		con:flush()
 	until not keep_alive
 

--- a/cqp/httpd.lua
+++ b/cqp/httpd.lua
@@ -48,8 +48,8 @@ local function parseurl(u)
 	local u = url.parse(u)
 	local s = url.parse_path(u.path)
 	local args = {}
-	if s.query then
-		for k,v in s.query:gmatch('([^&=?]-)=([^&=?]+)' ) do
+	if u.query then
+		for k,v in u.query:gmatch('([^&=?]-)=([^&=?]+)' ) do
 			args[k] = url.unescape(v)
 		end
 	end

--- a/cqp/process.lua
+++ b/cqp/process.lua
@@ -139,8 +139,8 @@ end
 function M.popenw(...)
 	M.init()
 	local rfd, wfd = posix.pipe()
-	posix.fcntl(rfd, posix.F_SETFD, posix.FD_CLOEXEC)
-	posix.fcntl(rfd, posix.F_SETFL, posix.O_NONBLOCK)
+	posix.fcntl(wfd, posix.F_SETFD, posix.FD_CLOEXEC)
+	posix.fcntl(wfd, posix.F_SETFL, posix.O_NONBLOCK)
 	local obj = setmetatable({
 		__cond = condition.new(),
 		__pid = spawn({stdin=rfd}, ...),

--- a/cqp/process.lua
+++ b/cqp/process.lua
@@ -18,6 +18,13 @@ local function spawn(info, ...)
 		posix.dup2(info.stdin or nulfd, 0)
 		posix.dup2(info.stdout or nulfd, 1)
 		posix.dup2(info.stderr or nulfd, 2)
+		if info.stdin then posix.close(info.stdin) end
+		if info.stdout then posix.close(info.stdout) end
+		if info.stderr then posix.close(info.stderr) end
+		posix.close(nulfd)
+		-- Unblock all signals, cqueues framework will block
+		-- many signals and that might cause issues with childs.
+		signal.unblock(signal.SIGKILL, signal.SIGTERM, signal.SIGHUP, signal.SIGCHLD)
 		posix.execp(...)
 		os.exit(0)
 	end


### PR DESCRIPTION
This is needed change to get Frisby.js REST API tester working. It sends HTTP headers lower case.
Note: Keys in `ctx.headers` change to lower case!
